### PR TITLE
python shebang fit to run in many environments

### DIFF
--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import json


### PR DESCRIPTION
make shebang use env so that the tool can run in many different environments. For example in virutalenv