### PR TITLE
add default for ban_reason as this field was removed in bitcoin core 0.20.1

### DIFF
--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -255,10 +255,10 @@ def refresh_metrics() -> None:
         do_smartfee(smartfee)
 
     for ban in banned:
-        BITCOIN_BAN_CREATED.labels(address=ban["address"], reason=ban["ban_reason"]).set(
+        BITCOIN_BAN_CREATED.labels(address=ban["address"], reason=ban.get("ban_reason", "manually added")).set(
             ban["ban_created"]
         )
-        BITCOIN_BANNED_UNTIL.labels(address=ban["address"], reason=ban["ban_reason"]).set(
+        BITCOIN_BANNED_UNTIL.labels(address=ban["address"], reason=ban.get("ban_reason", "manually added")).set(
             ban["banned_until"]
         )
 


### PR DESCRIPTION
In bitcoin core 0.20.1 the ban_reason field was removed:

https://bitcoin.org/en/release/v0.20.1#release-notes

> There is no method to list discouraged addresses. They are not returned by the listbanned RPC. That RPC also no longer reports the ban_reason field, as "manually added" is the only remaining option.

So this currently results in a key error:

```
bitcoin-prometheus-exporter_1  | Traceback (most recent call last):
bitcoin-prometheus-exporter_1  |   File "/monitor/bitcoind-monitor.py", line 348, in <module>
bitcoin-prometheus-exporter_1  |     main()
bitcoin-prometheus-exporter_1  |   File "/monitor/bitcoind-monitor.py", line 332, in main
bitcoin-prometheus-exporter_1  |     refresh_metrics()
bitcoin-prometheus-exporter_1  |   File "/monitor/bitcoind-monitor.py", line 258, in refresh_metrics
bitcoin-prometheus-exporter_1  |     BITCOIN_BAN_CREATED.labels(address=ban["address"], reason=ban["ban_reason"]).set(
bitcoin-prometheus-exporter_1  | KeyError: 'ban_reason'
```

I added the default "manually added" if the key is missing to retain backward compatibility 