### PR TITLE
Remove URL-quoting of rpc credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes to the project.
 ## [Unreleased]
 
 ### Added
+- Remove premature URL encoding of bitcoind rpc credentials .([#18][pr-18])
 - Support changing bind address with `METRICS_ADDR` environment variable ([#11][pr-11]).
 - Add `requirements.txt` file.
 - Set default `bad_reason` to "manually added" to support Bitcoin Core 0.20.1 ([#16][pr-16]).

--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -28,7 +28,6 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Union
-from urllib.parse import quote
 
 import riprova
 
@@ -169,7 +168,7 @@ def rpc_client_factory():
         return lambda: Proxy(btc_conf_file=BITCOIN_CONF_PATH, timeout=TIMEOUT)
     else:
         host = BITCOIN_RPC_HOST
-        host = "{}:{}@{}".format(quote(BITCOIN_RPC_USER), quote(BITCOIN_RPC_PASSWORD), host)
+        host = "{}:{}@{}".format(BITCOIN_RPC_USER, BITCOIN_RPC_PASSWORD, host)
         if BITCOIN_RPC_PORT:
             host = "{}:{}".format(host, BITCOIN_RPC_PORT)
         service_url = "{}://{}".format(BITCOIN_RPC_SCHEME, host)


### PR DESCRIPTION
Notably, the quoting result in bitcoind's cookie passwords not working when set via environment variables (since the trailing `=` gets translated into `%3D`).