### PR TITLE
Change default port

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The main script is a modified version of [`bitcoin-monitor.py`][source-gist], up
 ```
 docker run \
     --name=bitcoin-exporter \
-    -p 8334:8334 \
+    -p 9332:9332 \
     -e BITCOIN_RPC_HOST=bitcoin-node \
     -e BITCOIN_RPC_USER=alice \
     -e BITCOIN_RPC_PASSWORD=DONT_USE_THIS_YOU_WILL_GET_ROBBED_8ak1gI25KFTvjovL3gAM967mies3E= \

--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -129,7 +129,7 @@ BITCOIN_CONF_PATH = os.environ.get("BITCOIN_CONF_PATH")
 SMART_FEES = [int(f) for f in os.environ.get("SMARTFEE_BLOCKS", "2,3,5,20").split(",")]
 REFRESH_SECONDS = float(os.environ.get("REFRESH_SECONDS", "300"))
 METRICS_ADDR = os.environ.get("METRICS_ADDR", "")  # empty = any address
-METRICS_PORT = int(os.environ.get("METRICS_PORT", "8334"))
+METRICS_PORT = int(os.environ.get("METRICS_PORT", "9332"))
 RETRIES = int(os.environ.get("RETRIES", 5))
 TIMEOUT = int(os.environ.get("TIMEOUT", 30))
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     image: jvstein/bitcoin-prometheus-exporter:latest
     build: .
     ports:
-      - "8334:8334"
+      - "9332:9332"
     environment:
       BITCOIN_RPC_HOST: bitcoind
       BITCOIN_RPC_USER: "alice"


### PR DESCRIPTION
Since bitcoin-core 0.21.0 the port 8334 is used as an alternate RPC meant for tor connections: https://github.com/bitcoin/bitcoin/commit/a5266d4546c444cfd6d36cb63d2df52ce9e689e2

I'm not particularly attached to 9332, though most prometheus exporters have ports in the 9xxx range.