### PR TITLE
Add support for BitcoinCash nodes and provide custom HASHPS blocks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.8-alpine3.13
 
 LABEL org.opencontainers.image.title "bitcoin-prometheus-exporter"
 LABEL org.opencontainers.image.description "Prometheus exporter for bitcoin nodes"

--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -21,7 +21,7 @@ import os
 import signal
 import sys
 import socket
-
+from decimal import Decimal
 from datetime import datetime
 from functools import lru_cache
 from typing import Any
@@ -123,7 +123,7 @@ PROCESS_TIME = Counter(
     "bitcoin_exporter_process_time", "Time spent processing metrics from bitcoin node"
 )
 
-SATS_PER_COIN = 1e8
+SATS_PER_COIN = Decimal(1e8)
 
 BITCOIN_RPC_SCHEME = os.environ.get("BITCOIN_RPC_SCHEME", "http")
 BITCOIN_RPC_HOST = os.environ.get("BITCOIN_RPC_HOST", "localhost")
@@ -236,17 +236,17 @@ def do_smartfee(num_blocks: int) -> None:
 
 def hashps_gauge_suffix(nblocks):
     if nblocks < 0:
-        return "neg%d" % -nblocks
+        return "_neg%d" % -nblocks
     if nblocks == 120:
         return ""
-    return "%d" % nblocks
+    return "_%d" % nblocks
 
 
 def hashps_gauge(num_blocks: int) -> Gauge:
     gauge = BITCOIN_HASHPS_GAUGES.get(num_blocks)
     if gauge is None:
         gauge = Gauge(
-            "bitcoin_hashps_%s" % hashps_gauge_suffix(num_blocks),
+            "bitcoin_hashps%s" % hashps_gauge_suffix(num_blocks),
             "Estimated network hash rate per second for the last %d blocks" % num_blocks,
         )
         BITCOIN_HASHPS_GAUGES[num_blocks] = gauge

--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -237,10 +237,10 @@ def do_smartfee(num_blocks: int) -> None:
 
 def hashps_gauge_suffix(nblocks):
     if nblocks < 0:
-        return "_NEG%d" % -nblocks
+        return "neg%d" % -nblocks
     if nblocks == 120:
         return ""
-    return "_%d" % nblocks
+    return "%d" % nblocks
 
 
 def hashps_gauge(num_blocks: int) -> Gauge:

--- a/bitcoind-monitor.py
+++ b/bitcoind-monitor.py
@@ -133,7 +133,6 @@ BITCOIN_RPC_PASSWORD = os.environ.get("BITCOIN_RPC_PASSWORD")
 BITCOIN_CONF_PATH = os.environ.get("BITCOIN_CONF_PATH")
 HASHPS_BLOCKS = [int(b) for b in os.environ.get("HASHPS_BLOCKS", "-1,1,120").split(",") if b != '']
 SMART_FEES = [int(f) for f in os.environ.get("SMARTFEE_BLOCKS", "2,3,5,20").split(",") if f != '']
-REFRESH_SECONDS = float(os.environ.get("REFRESH_SECONDS", "300"))
 METRICS_ADDR = os.environ.get("METRICS_ADDR", "")  # empty = any address
 METRICS_PORT = int(os.environ.get("METRICS_PORT", "9332"))
 RETRIES = int(os.environ.get("RETRIES", 5))


### PR DESCRIPTION
This PR adds support for BitcoinCash nodes the following way:
- Add configurable values for NASHPS block counts - BitcoinCash nodes does not support the default "-1" value.
- Set latest block weight metric only if present - BitcoinCash nodes does not return the block weight.

Additionally, fixes the following issues:
- Providing an empty value for "SMART_FEES" would crash the process. Now, when an empty value is set, fees metrics will not be exposed.
- Downgraded the Docker base image to alpine 3.13 to fix a conflict issue with libressl (see https://gitlab.alpinelinux.org/alpine/aports/-/issues/12763).